### PR TITLE
Dockerfile: use specific version of the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/fluentd
+FROM bitnami/fluentd:1.12.0-debian-10-r16
 
 ## Install custom Fluentd plugins
 RUN fluent-gem install 'fluent-plugin-dedot_filter' \


### PR DESCRIPTION
This will ensure reproducible build and also gives us version reference we can use to version our images.