### PR TITLE
SRE-995: add azure storage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,16 @@
 FROM bitnami/fluentd:1.13.3-debian-10-r17
 
-## Install custom Fluentd plugins
+USER root
+
+# Compiler for fluent-plugin-azure-storage-append-blob-lts
+RUN apt-get update && apt-get install -y gcc make \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install custom Fluentd plugins
 RUN fluent-gem install 'fluent-plugin-dedot_filter' \
     && fluent-gem install 'fluent-plugin-label-router' \
-    && fluent-gem install 'fluent-plugin-elasticsearch' \
     && fluent-gem install 'fluent-plugin-record-modifier' \
     && fluent-gem install 'fluent-plugin-filter_empty_keys' \
-    && fluent-gem install 'fluent-plugin-s3' \
-    && fluent-gem install 'fluent-plugin-prometheus'
+    && fluent-gem install 'fluent-plugin-azure-storage-append-blob-lts'
+
+USER 1001


### PR DESCRIPTION
Adding Azure Storage [plugin](https://github.com/elsesiy/fluent-plugin-azure-storage-append-blob-lts) and removing install of already installed plugins.

List of initialized plugins during the container startup:
```
2021-10-07 09:04:14 +0000 [info]: gem 'fluent-plugin-azure-storage-append-blob-lts' version '0.6.3'
2021-10-07 09:04:14 +0000 [info]: gem 'fluent-plugin-concat' version '2.5.0'
2021-10-07 09:04:14 +0000 [info]: gem 'fluent-plugin-dedot_filter' version '1.0.0'
2021-10-07 09:04:14 +0000 [info]: gem 'fluent-plugin-detect-exceptions' version '0.0.13'
2021-10-07 09:04:14 +0000 [info]: gem 'fluent-plugin-elasticsearch' version '5.0.5'
2021-10-07 09:04:14 +0000 [info]: gem 'fluent-plugin-filter_empty_keys' version '0.0.3'
2021-10-07 09:04:14 +0000 [info]: gem 'fluent-plugin-grafana-loki' version '1.2.16'
2021-10-07 09:04:14 +0000 [info]: gem 'fluent-plugin-kafka' version '0.16.3'
2021-10-07 09:04:14 +0000 [info]: gem 'fluent-plugin-kubernetes_metadata_filter' version '2.7.2'
2021-10-07 09:04:14 +0000 [info]: gem 'fluent-plugin-label-router' version '0.2.10'
2021-10-07 09:04:14 +0000 [info]: gem 'fluent-plugin-multi-format-parser' version '1.0.0'
2021-10-07 09:04:14 +0000 [info]: gem 'fluent-plugin-prometheus' version '2.0.1'
2021-10-07 09:04:14 +0000 [info]: gem 'fluent-plugin-record-modifier' version '2.1.0'
2021-10-07 09:04:14 +0000 [info]: gem 'fluent-plugin-rewrite-tag-filter' version '2.4.0'
2021-10-07 09:04:14 +0000 [info]: gem 'fluent-plugin-s3' version '1.6.0'
2021-10-07 09:04:14 +0000 [info]: gem 'fluent-plugin-systemd' version '1.0.5'
```